### PR TITLE
Remove riscv64 support

### DIFF
--- a/.github/workflows/publish_docker-images-edge.yml
+++ b/.github/workflows/publish_docker-images-edge.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     uses: ./.github/workflows/service_docker-build-and-publish.yml
     with:
-      tag-prefix: 'edge-${{ env.PR_NUMBER }}-'
+      tag-prefix: "edge-${{ env.PR_NUMBER }}-"
       checkout-type: branch
     secrets: inherit

--- a/.github/workflows/publish_docker-images-edge.yml
+++ b/.github/workflows/publish_docker-images-edge.yml
@@ -3,13 +3,10 @@ name: Docker Publish (Edge - Pull Request)
 on:
   pull_request:
 
-env:
-  PR_NUMBER: ${{ github.event.pull_request.number }}
-
 jobs:
   build:
     uses: ./.github/workflows/service_docker-build-and-publish.yml
     with:
-      tag-prefix: "edge-${{ env.PR_NUMBER }}-"
+      tag-prefix: "edge-${{ github.event.pull_request.number }}-"
       checkout-type: branch
     secrets: inherit

--- a/.github/workflows/publish_docker-images-edge.yml
+++ b/.github/workflows/publish_docker-images-edge.yml
@@ -2,8 +2,6 @@ name: Docker Publish (Edge - Pull Request)
 
 on:
   pull_request:
-    branches:
-    - '!dev'
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -86,7 +86,6 @@ jobs:
             linux/arm/v7
             linux/arm64/v8
             linux/ppc64le
-            linux/riscv64
             linux/s390x
           build-args: |
             BASE_OS_IMAGE=${{ matrix.linux-flavor }}:${{ matrix.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN mkdir -p $S6_DIR; \
         arm*    ) export S6_ARCH='arm'     ;; \
         i4*     ) export S6_ARCH='i486'    ;; \
         i6*     ) export S6_ARCH='i686'    ;; \
-        riscv64 ) export S6_ARCH='riscv64' ;; \
         s390*   ) export S6_ARCH='s390x'   ;; \
         *       ) export S6_ARCH='x86_64'  ;; \
     esac; \


### PR DESCRIPTION
# Related issues
- Fixes #8 

# What this PR does
- Removes `riscv64` because it is no longer supported by Ubuntu 22.04
- Improve PR actions